### PR TITLE
Fix PATH

### DIFF
--- a/info.plist
+++ b/info.plist
@@ -725,7 +725,7 @@ python setid.py $1</string>
 	<key>variables</key>
 	<dict>
 		<key>PATH</key>
-		<string>/usr/local/bin/:$PATH</string>
+		<string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
 	</dict>
 	<key>variablesdontexport</key>
 	<array/>


### PR DESCRIPTION
Alfred’s Workflow Environment Variables section is not a shell—it doesn’t expand `$PATH`, you have to be explicit about it. Also added the path for people on Apple Silicon.